### PR TITLE
Configure [repositories] section rather than deprecated [trac] repository_dir.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ trac-github plugins:
     [github]
     repository = <user>/<project>
 
-    [trac]
-    repository_dir = /home/trac/<project>.git
-    repository_type = git
+    [repositories]
+    .dir = /home/trac/<project>.git
+    .type = git
 
 In Trac 0.12, use `tracext.git.* = enabled` instead of
 `tracopt.versioncontrol.git.* = enabled`.


### PR DESCRIPTION
Update documentation for `[repositories]` section.

`[trac] repository_dir` is deprecated in Trac 0.12 and later. The `[repositories]` section should be configured instead.