### PR TITLE
Specify `requests-oauthlib` in `extras_require`.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,5 +12,10 @@ setup(
     namespace_packages=['tracext'],
     platforms='all',
     license='BSD',
-    entry_points={'trac.plugins': ['github = tracext.github']},
+    extras_require={'oauth': ['requests_oauthlib >= 0.5']},
+    entry_points={'trac.plugins': [
+        'github.browser = tracext.github:GitHubBrowser',
+        'github.loginmodule = tracext.github:GitHubLoginModule[oauth]',
+        'github.postcommithook = tracext.github:GitHubPostCommitHook',
+    ]},
 )

--- a/tracext/__init__.py
+++ b/tracext/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)


### PR DESCRIPTION
The prevents the component from loading when the dependencies are not met.