### PR TITLE
Optionally request access to email addresses on GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,10 @@ stored in the preferences on the first login.
 
     [github]
     request_email = true
+    preferred_email_regex = ^.*@example.org$
+
+if specified, the first address matching the optional preferred_email_regex will be
+used instead of the primary address.
 
 Note that the Trac mail address will only be initialized on the first login.
 Users can still change or remove the email address from their Trac account.

--- a/README.md
+++ b/README.md
@@ -165,6 +165,19 @@ configuration file, you have some alternatives:
 - If `client_secret` is anything else, trac-github will interpret it as a file
   name and use the contents of that file as client secret.
 
+By default the preferences will use the public email address of the
+authenticated GitHub user. If the public email address is not set, the field
+will be empty. If the email address is important for your Trac installation
+(for example for notifications), the request_email option can be set to always
+request access to all email addresses from GitHub. The primary address will be
+stored in the preferences on the first login.
+
+    [github]
+    request_email = true
+
+Note that the Trac mail address will only be initialized on the first login.
+Users can still change or remove the email address from their Trac account.
+
 ### Browser
 
 **`tracext.github.GitHubBrowser`** redirects changeset TracLinks to

--- a/tracext/github.py
+++ b/tracext/github.py
@@ -6,7 +6,7 @@ import re
 from genshi.builder import tag
 
 import trac
-from trac.config import ListOption, Option
+from trac.config import ListOption, BoolOption, Option
 from trac.core import Component, implements
 from trac.util.translation import _
 from trac.versioncontrol.api import is_default, NoSuchChangeset, RepositoryManager
@@ -17,6 +17,9 @@ from trac.web.chrome import add_warning
 
 
 class GitHubLoginModule(LoginModule):
+
+    request_email = BoolOption('github', 'request_email', 'false',
+            doc="Request access to the email address of the GitHub user.")
 
     # INavigationContributor methods
 
@@ -89,11 +92,19 @@ class GitHubLoginModule(LoginModule):
             self._reject_oauth(req, exc)
 
         user = oauth.get('https://api.github.com/user').json()
+        name = user.get('name')
+        email = user.get('email')
+        if self.request_email:
+            emails = oauth.get('https://api.github.com/user/emails').json()
+            for item in emails:
+                if item['primary']:
+                    email = item['email']
+                    break
         # Small hack to pass the username to _do_login.
         req.environ['REMOTE_USER'] = user['login']
         # Save other available values in the session.
-        req.session.setdefault('name', user.get('name') or '')
-        req.session.setdefault('email', user.get('email') or '')
+        req.session.setdefault('name', name or '')
+        req.session.setdefault('email', email or '')
 
         return super(GitHubLoginModule, self)._do_login(req)
 
@@ -108,12 +119,15 @@ class GitHubLoginModule(LoginModule):
 
     def _oauth_session(self, req, state=None):
         client_id = self._client_config('id')
+        scope = ['']
+        if self.request_email:
+            scope = ['user:email']
         redirect_uri = req.abs_href.github('oauth')
         # Inner import to avoid a hard dependency on requests-oauthlib.
         from requests_oauthlib import OAuth2Session
         return OAuth2Session(
             client_id,
-            scope=[''],
+            scope=scope,
             redirect_uri=redirect_uri,
             state=state,
         )


### PR DESCRIPTION
With `request_email=true` a Trac instance can request access to all email addresses of the authenticated GitHub user. From these, either the primary email address will be used for the session, or a specific address can be selected with `preferred_email_regex`.