### PR TITLE
Optionally request access to email addresses on GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,19 @@ configuration file, you have some alternatives:
 - If `client_secret` is anything else, trac-github will interpret it as a file
   name and use the contents of that file as client secret.
 
+By default the preferences will use the public email address of the
+authenticated GitHub user. If the public email address is not set, the field
+will be empty. If the email address is important for your Trac installation
+(for example for notifications), the request_email option can be set to always
+request access to all email addresses from GitHub. The primary address will be
+stored in the preferences on the first login.
+
+    [github]
+    request_email = true
+
+Note that the Trac mail address will only be initialized on the first login.
+Users can still change or remove the email address from their Trac account.
+
 ### Browser
 
 **`tracext.github.GitHubBrowser`** redirects changeset TracLinks to

--- a/README.md
+++ b/README.md
@@ -169,12 +169,16 @@ configuration file, you have some alternatives:
 By default the preferences will use the public email address of the
 authenticated GitHub user. If the public email address is not set, the field
 will be empty. If the email address is important for your Trac installation
-(for example for notifications), the request_email option can be set to always
-request access to all email addresses from GitHub. The primary address will be
-stored in the preferences on the first login.
+(for example for notifications), the `request_email` option can be set to
+always request access to all email addresses from GitHub. The primary address
+will be stored in the preferences on the first login.
 
     [github]
     request_email = true
+    preferred_email_domain = example.org
+
+if specified, the first address matching the optional `preferred_email_domain`
+will be used instead of the primary address.
 
 Note that the Trac mail address will only be initialized on the first login.
 Users can still change or remove the email address from their Trac account.

--- a/tracext/github.py
+++ b/tracext/github.py
@@ -92,19 +92,21 @@ class GitHubLoginModule(LoginModule):
         client_secret = self._client_config('secret')
         # Inner import to avoid a hard dependency on requests-oauthlib.
         import oauthlib
+        github_oauth_url = os.environ.get("TRAC_GITHUB_OAUTH_URL", "https://github.com/")
+        github_api_url = os.environ.get("TRAC_GITHUB_API_URL", "https://api.github.com/")
         try:
             oauth.fetch_token(
-                'https://github.com/login/oauth/access_token',
+                github_oauth_url + 'login/oauth/access_token',
                 authorization_response=authorization_response,
                 client_secret=client_secret)
         except oauthlib.oauth2.OAuth2Error as exc:
             self._reject_oauth(req, exc)
 
-        user = oauth.get('https://api.github.com/user').json()
+        user = oauth.get(github_api_url + 'user').json()
         name = user.get('name')
         email = user.get('email')
         if self.request_email:
-            emails = oauth.get('https://api.github.com/user/emails').json()
+            emails = oauth.get(github_api_url + 'user/emails').json()
             for item in emails:
                 if not item['verified']:
                     # ignore unverified email addresses

--- a/tracext/github.py
+++ b/tracext/github.py
@@ -30,6 +30,10 @@ class GitHubLoginModule(LoginModule):
         'github', 'request_email', 'false',
         doc="Request access to the email address of the GitHub user.")
 
+    preferred_email_domain = Option(
+        'github', 'preferred_email_domain', '',
+        doc="Prefer email address under this domain over the primary address.")
+
     # INavigationContributor methods
 
     def get_active_navigation_item(self, req):
@@ -120,9 +124,14 @@ class GitHubLoginModule(LoginModule):
                     if not item['verified']:
                         # ignore unverified email addresses
                         continue
-                    if item['primary']:
+                    if (self.preferred_email_domain and
+                        item['email'].endswith('@' + self.preferred_email_domain)):
                         email = item['email']
                         break
+                    if item['primary']:
+                        email = item['email']
+                        if not self.preferred_email_domain:
+                            break
             except Exception as exc: # pylint: disable=broad-except
                 self._reject_oauth(
                     req, exc,

--- a/tracext/github.py
+++ b/tracext/github.py
@@ -92,6 +92,7 @@ class GitHubLoginModule(LoginModule):
         client_secret = self._client_config('secret')
         # Inner import to avoid a hard dependency on requests-oauthlib.
         import oauthlib
+        import requests
         github_oauth_url = os.environ.get("TRAC_GITHUB_OAUTH_URL", "https://github.com/")
         github_api_url = os.environ.get("TRAC_GITHUB_API_URL", "https://api.github.com/")
         try:
@@ -99,7 +100,7 @@ class GitHubLoginModule(LoginModule):
                 github_oauth_url + 'login/oauth/access_token',
                 authorization_response=authorization_response,
                 client_secret=client_secret)
-        except oauthlib.oauth2.OAuth2Error as exc:
+        except (oauthlib.oauth2.OAuth2Error, requests.exceptions.ConnectionError) as exc:
             self._reject_oauth(req, exc)
 
         user = oauth.get(github_api_url + 'user').json()

--- a/tracext/github.py
+++ b/tracext/github.py
@@ -106,6 +106,9 @@ class GitHubLoginModule(LoginModule):
         if self.request_email:
             emails = oauth.get('https://api.github.com/user/emails').json()
             for item in emails:
+                if not item['verified']:
+                    # ignore unverified email addresses
+                    continue
                 if item['primary']:
                     email = item['email']
                     break

--- a/tracext/github.py
+++ b/tracext/github.py
@@ -114,14 +114,20 @@ class GitHubLoginModule(LoginModule):
                 req, exc,
                 reason=_("An error occurred while communicating with the GitHub API"))
         if self.request_email:
-            emails = oauth.get(github_api_url + 'user/emails').json()
-            for item in emails:
-                if not item['verified']:
-                    # ignore unverified email addresses
-                    continue
-                if item['primary']:
-                    email = item['email']
-                    break
+            try:
+                emails = oauth.get(github_api_url + 'user/emails').json()
+                for item in emails:
+                    if not item['verified']:
+                        # ignore unverified email addresses
+                        continue
+                    if item['primary']:
+                        email = item['email']
+                        break
+            except Exception as exc: # pylint: disable=broad-except
+                self._reject_oauth(
+                    req, exc,
+                    reason=_("An error occurred while retrieving your email address "
+                             "from the GitHub API"))
         # Small hack to pass the username to _do_login.
         req.environ['REMOTE_USER'] = login
         # Save other available values in the session.


### PR DESCRIPTION
With request_email=true a Trac instance can request access to all email addresses of the authenticated GitHub user. From these, either the primary email address will be used for the session, or a specific address can be selected with preferred_email_regex.

See #102. I opened a new pull request because that is easier for me than asking @raimue to update his branch now that I rebased and added more tests.

Increases test coverage to 99% and does not add new pylint warnings.