### PR TITLE
tests: fix failing tests due to Babel's LazyProxy

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -346,7 +346,7 @@ class GitHubLoginModuleTests(TracGitHubTests):
         response = session.get(URL)
         self.assertEqual(response.status_code, 200)
         self.assertIn(
-            _("Invalid request. Please try to login again."), response.text)
+            str(_("Invalid request. Please try to login again.")), response.text)
 
     def testOauthInvalidStateWithoutSession(self):
         session = requests.Session()
@@ -363,7 +363,7 @@ class GitHubLoginModuleTests(TracGitHubTests):
         response = session.get(URL)
         self.assertEqual(response.status_code, 200)
         self.assertIn(
-            _("Invalid request. Please try to login again."), response.text)
+            str(_("Invalid request. Please try to login again.")), response.text)
 
     def testLogout(self):
         response = requests.get(URL + '/github/logout', allow_redirects=False)
@@ -477,7 +477,7 @@ class GitHubLoginModuleConfigurationTests(TracGitHubTests):
         """
         errmsg, emails = self.attemptValidOauth(self.trac_env_broken, "")
         self.assertIn(
-            _("Invalid request. Please try to login again."),
+            str(_("Invalid request. Please try to login again.")),
             errmsg,
             "OAuth Authorization Request with unavailable backend should not succeed.")
 
@@ -487,7 +487,7 @@ class GitHubLoginModuleConfigurationTests(TracGitHubTests):
             return 403, {}
         errmsg, emails = self.attemptValidOauth(self.trac_env, cb)
         self.assertIn(
-            _("Invalid request. Please try to login again."),
+            str(_("Invalid request. Please try to login again.")),
             errmsg,
             "OAuth Authorization Request with failing backend should not succeed.")
 
@@ -508,7 +508,7 @@ class GitHubLoginModuleConfigurationTests(TracGitHubTests):
         """
         errmsg, emails = self.attemptValidOauth(self.trac_env_broken_api, self.oauthCallbackSuccess)
         self.assertIn(
-            _("An error occurred while communicating with the GitHub API"),
+            str(_("An error occurred while communicating with the GitHub API")),
             errmsg,
             "Request to unavailable API with valid OAuth token should print an error.")
 
@@ -521,7 +521,7 @@ class GitHubLoginModuleConfigurationTests(TracGitHubTests):
                                                 self.oauthCallbackSuccess,
                                                 retcode=403)
         self.assertIn(
-            _("An error occurred while communicating with the GitHub API"),
+            str(_("An error occurred while communicating with the GitHub API")),
             errmsg,
             "Failing API request with valid OAuth token should print an error.")
 
@@ -545,7 +545,7 @@ class GitHubLoginModuleConfigurationTests(TracGitHubTests):
                 self.trac_env, self.oauthCallbackSuccess, retcode=200,
                 answers=answers, request_email=True)
         self.assertIn(
-            _("An error occurred while retrieving your email address from the GitHub API"),
+            str(_("An error occurred while retrieving your email address from the GitHub API")),
             errmsg,
             "Failing email API request with valid OAuth token should print an error.")
 


### PR DESCRIPTION
When Babel is installed, these tests failed with this exception:
TypeError: 'in <string>' requires string as left operand, not LazyProxy

Forcing conversion to a string solves the problem.