### PR TITLE
Run trac-github-update hook after updating repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,9 @@ field and set the "Content type" to `application/json`. Click "Add webhook".
 If you click on the webhook you just created, at the bottom of the page, you
 should see that a "ping" payload was successufully delivered to Trac
 
+Optionally, you can run additional actions every time GitHub triggers a webhook
+by placing a custom executable script at `<project>.git/hooks/trac-github-update`.
+
 ### Authentication
 
 **`tracext.github.GitHubLoginModule`** provides authentication through

--- a/tracext/github.py
+++ b/tracext/github.py
@@ -221,7 +221,7 @@ class GitHubMixin(Component):
 
         hmac_hash = hmac.new(
             webhook_secret.encode('utf-8'),
-            reqdata.encode('utf-8'),
+            reqdata,
             supported_algorithms[algorithm])
         computed = hmac_hash.hexdigest()
 

--- a/tracext/github.py
+++ b/tracext/github.py
@@ -930,7 +930,7 @@ class GitHubPostCommitHook(GitHubMixin, Component):
             self.log.error(u'Payload contains unknown %s',
                     describe_commits(unknown))
 
-        status = 200 if output else 204
+        status = 200
 
         git_dir = git.rev_parse('--git-dir').rstrip('\n')
         hook = os.path.join(git_dir, 'hooks', 'trac-github-update')
@@ -952,6 +952,9 @@ class GitHubPostCommitHook(GitHubMixin, Component):
 
         for line in output.splitlines():
             self.log.debug(line)
+
+        if status == 200 and not output:
+            status = 204
 
         req.send(output.encode('utf-8'), 'text/plain', status)
 

--- a/tracext/github.py
+++ b/tracext/github.py
@@ -875,15 +875,6 @@ class GitHubPostCommitHook(GitHubMixin, Component):
             self.log.warning(u'Method not allowed (%s)' % req.method)
             req.send(msg.encode('utf-8'), 'text/plain', 405)
 
-        event = req.get_header('X-GitHub-Event')
-        if event == 'ping':
-            payload = json.loads(req.read())
-            req.send(payload['zen'].encode('utf-8'), 'text/plain', 200)
-        elif event != 'push':
-            msg = u'Only ping and push are supported\n'
-            self.log.warning(msg.rstrip('\n'))
-            req.send(msg.encode('utf-8'), 'text/plain', 400)
-
         # Verify the event's signature
         reqdata = req.read()
         signature = req.get_header('X-Hub-Signature')
@@ -891,6 +882,15 @@ class GitHubPostCommitHook(GitHubMixin, Component):
             msg = u'Webhook signature verification failed\n'
             self.log.warning(msg.rstrip('\n')) # pylint: disable=no-member
             req.send(msg.encode('utf-8'), 'text/plain', 403)
+
+        event = req.get_header('X-GitHub-Event')
+        if event == 'ping':
+            payload = json.loads(reqdata)
+            req.send(payload['zen'].encode('utf-8'), 'text/plain', 200)
+        elif event != 'push':
+            msg = u'Only ping and push are supported\n'
+            self.log.warning(msg.rstrip('\n'))
+            req.send(msg.encode('utf-8'), 'text/plain', 400)
 
         output = u'Running hook on %s\n' % (reponame or '(default)')
 

--- a/tracext/github.py
+++ b/tracext/github.py
@@ -935,19 +935,19 @@ class GitHubPostCommitHook(GitHubMixin, Component):
         git_dir = git.rev_parse('--git-dir').rstrip('\n')
         hook = os.path.join(git_dir, 'hooks', 'trac-github-update')
         if os.path.isfile(hook):
-            output += "* Running trac-github-update hook\n"
+            output += u'* Running trac-github-update hook\n'
             try:
                 p = Popen(hook, cwd=git_dir,
                           stdin=PIPE, stdout=PIPE, stderr=STDOUT,
                           close_fds=trac.util.compat.close_fds)
             except Exception as e:
-                output += "Error: hook execution failed with exception\n%s" % (traceback.format_exc(),)
+                output += u'Error: hook execution failed with exception\n%s' % (traceback.format_exc(),)
                 status = 500
             else:
                 hookoutput = p.communicate(input=reqdata)[0]
                 output += hookoutput.decode('utf-8')
                 if p.returncode != 0:
-                    output += "Error: hook failed with exit code %d\n" % (p.returncode,)
+                    output += u'Error: hook failed with exit code %d\n' % (p.returncode,)
                     status = 500
 
         for line in output.splitlines():


### PR DESCRIPTION
Git has no option to run a hook locally when 'git remote update' fetches
new commits. In order to be able to trigger custom actions on update
(for example commit mail notifications), this adds suppport for
a 'trac-github-update' hook. This hook will be called each time the
GitHub Webhook updates the repository, and receives the JSON payload as
sent by GitHub on standard input.
