### PR TITLE
Ignore case when comparing preferred email domains

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -760,6 +760,33 @@ class GitHubLoginModuleConfigurationTests(TracGitHubTests):
                               preferred_email_domain='example.org')
         self.assertEqual(email, ['lololort@example.com'])
 
+    def testPreferredEmailCaseInsensitive(self):
+        """
+        Test that the preferred email domain is honoured regardless of case.
+        """
+        answers = {
+            '/user': {
+                'user': 'trololol',
+                'login': 'trololol'
+            },
+            '/user/emails': [
+                {
+                    'email': 'lololort@example.com',
+                    'verified': True,
+                    'primary': True
+                },
+                {
+                    'email': 'lololort@EXAMPLE.NET',
+                    'verified': True,
+                    'primary': False
+                },
+            ]
+        }
+
+        email = self.getEmail(answers, request_email=True,
+                              preferred_email_domain='example.net')
+        self.assertEqual(email, ['lololort@EXAMPLE.NET'])
+
 
 class GitHubPostCommitHookTests(TracGitHubTests):
 

--- a/tracext/github.py
+++ b/tracext/github.py
@@ -145,7 +145,8 @@ class GitHubLoginModule(LoginModule):
                         # ignore unverified email addresses
                         continue
                     if (self.preferred_email_domain and
-                        item['email'].endswith('@' + self.preferred_email_domain)):
+                        item['email'].lower().endswith(
+                            '@' + self.preferred_email_domain.lower())):
                         email = item['email']
                         break
                     if item['primary']:


### PR DESCRIPTION
Domains are not case-sensitive and differences in case should not cause
a preferred email to be ignored. Add a test that verifies the correct
behavior.

Review request: @rjollos, @raimue.