### PR TITLE
Restore missing `BROWSER_VIEW` and `FILE_VIEW` permissions

### DIFF
--- a/tracext/github.py
+++ b/tracext/github.py
@@ -247,6 +247,14 @@ class GitHubBrowser(GitHubMixin, ChangesetModule):
     repository = Option('github', 'repository', '',
             doc="Repository name on GitHub (<user>/<project>)")
 
+    # IPermissionRequestor methods
+
+    def get_permission_actions(self):
+        # BROWSER_VIEW & FILE_VIEW defined by disabled BrowserModule,
+        # but needed for [timeline] changeset_show_files option
+        return ['BROWSER_VIEW', 'FILE_VIEW'] + \
+               super(GitHubBrowser, self).get_permission_actions()
+
     # IRequestHandler methods
 
     def match_request(self, req):


### PR DESCRIPTION
The permissions are needed for the `[timeline]` `changeset_show_files` option to be effective. See [ChangesetModule.render_timeline_event](https://trac.edgewall.org/browser/tags/trac-1.2.1/trac/versioncontrol/web_ui/changeset.py?marks=948,957,979#L923).