### PR TITLE
Enable Travis CI builds & Coveralls reports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: python
+python:
+  - "2.7"
+install:
+  - pip install coverage lxml requests requests-oauthlib python-coveralls Trac
+  - pip install -e .
+  - pip freeze
+script:
+  - coverage erase
+  - ./runtests.py --with-coverage --with-trac-log
+after_success:
+  - coveralls


### PR DESCRIPTION
This pull request enables Travis CI builds for trac-github which will run the test suite. Additionally, the produced coverage data will be pushed to coveralls.io for visualization.

This change requires enabling Travis CI support for this repository. To do that:
1. Go to https://travis-ci.org/ and sign in with GitHub
2. Go to your profile page by clicking your name at the top right
3. Use the search field to locate the trac-github repository and click the slider to enable builds
4. Click the settings button next to the slider to open the settings
5. Under General, enable building only if a .travis.yml file is present

An owner of the trac-hacks organization needs to do that (that would be @rjollos, I guess).