### PR TITLE
Use modern GitHub API to read team members

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -3,7 +3,7 @@ run-name: Run test suite for trac-github
 on: [pull_request]
 jobs:
   runtests-py2:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container:
       image: python:2.7.18-buster
 

--- a/runtests.py
+++ b/runtests.py
@@ -1528,8 +1528,8 @@ class GitHubGroupsProviderTests(TracGitHubTests):
                     "slug": u"gentlepeople"
                 }
             ],
-            '/teams/1/members': team1members,
-            '/teams/12/members': team12members
+            '/organizations/%s/team/1/members' % self.organization: team1members,
+            '/organizations/%s/team/12/members' % self.organization: team12members
         })
 
         with TracContext(self, env=self.tracd_env_debug, **self.trac_env):
@@ -1711,8 +1711,8 @@ class GitHubGroupsProviderTests(TracGitHubTests):
                     "slug": u"gentlepeople"
                 }
             ],
-            '/teams/1/members': team1members,
-            '/teams/12/members': team12members
+            '/organizations/%s/team/1/members' % self.organization: team1members,
+            '/organizations/%s/team/12/members' % self.organization: team12members
         })
 
         update = {
@@ -1744,7 +1744,7 @@ class GitHubGroupsProviderTests(TracGitHubTests):
                         "slug": u"gentlepeople"
                     }
                 ],
-                '/teams/12/members': team12members
+                '/organizations/%s/team/12/members' % self.organization: team12members
             })
 
             # Send the delete event
@@ -1829,7 +1829,7 @@ class GitHubGroupsProviderTests(TracGitHubTests):
                         "slug": u"justice-league"
                     },
                 ],
-                '/teams/1/members': team1members,
+                '/organizations/%s/team/1/members' % self.organization: team1members,
             })
 
             # Send the update event
@@ -1872,7 +1872,7 @@ class GitHubGroupsProviderTests(TracGitHubTests):
                     "slug": u"justice-league"
                 },
             ],
-            '/teams/1/members': list(team1members)
+            '/organizations/%s/team/1/members' % self.organization: list(team1members)
         })
 
         update = {
@@ -1894,7 +1894,7 @@ class GitHubGroupsProviderTests(TracGitHubTests):
                         "slug": u"justice-league"
                     },
                 ],
-                '/teams/1/members': list(team1members)
+                '/organizations/%s/team/1/members' % self.organization: list(team1members)
             })
 
             # Send the update event
@@ -1937,7 +1937,7 @@ class GitHubGroupsProviderTests(TracGitHubTests):
                     "slug": u"justice-league"
                 },
             ],
-            '/teams/1/members': list(team1members)
+            '/organizations/%s/team/1/members' % self.organization: list(team1members)
         })
 
         update = {
@@ -1959,7 +1959,7 @@ class GitHubGroupsProviderTests(TracGitHubTests):
                         "slug": u"justice-league"
                     },
                 ],
-                '/teams/1/members': list(team1members)
+                '/organizations/%s/team/1/members' % self.organization: list(team1members)
             })
 
             # Send the update event

--- a/tracext/github/__init__.py
+++ b/tracext/github/__init__.py
@@ -475,11 +475,12 @@ class GitHubTeam(GitHubUserCollection):
         :param slug: the GitHub team shortname in URL representation
         """
         self._teamid = teamid
+        self._orgid = org
         fullname = '-'.join(['github', org, slug])
         super(GitHubTeam, self).__init__(api, env, fullname)
 
     def _apicall_parameters(self):
-        return ("teams/{}/members", self._teamid)
+        return ("organizations/{}/team/{}/members", self._orgid, self._teamid)
 
 #class GitHubOrgMembers(GitHubUserCollection):
 #    """


### PR DESCRIPTION
The old API was deprecated a while ago, and while I couldn't find notices of it being sunset or affected by brownouts right now, I do notice that it has stopped working currently — whether that's temporary or permanent I don't know, but it doesn't hurt to merge this improvement.

Closes: #135